### PR TITLE
Improve changelog entry selection & wiki template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,7 @@
-<- THIS TEXT WILL BE ADDED TO THE TF MODULE CHANGE LOG !!!
-PLEASE REPLACE WITH SOMETHING MEANINGFUL ->
+<!-- Describe your Pull Request here, as normal :) -->
+
+## Changelog entry
+```
+TODO: Replace this inner text with a useful message
+for users of the effected modules!
+```

--- a/.github/workflows/monorepo-wiki.yml
+++ b/.github/workflows/monorepo-wiki.yml
@@ -36,13 +36,22 @@ jobs:
             const utf8 = { encoding: 'utf-8' };
             const msgParts = [];
 
+            const newPage = `<!--
+            Replace this comment with an introduction about the module!
+            Text and markdown up here will be preserved over time,
+            while the rest of the wiki page is generated from the release process.
+            -->
+
+            <!-- WARNING: Sections below this comment will be replaced and/or added to automatically. -->
+            `;
+
             for (const folder of await readdir('outputs', { withFileTypes: true })) {
               if (!folder.isDirectory()) continue;
               const readText = (name) => readFile(name, utf8).then(x => x.trim());
 
               const wikiPath = `wiki/generated/${folder.name}.md`;
               const prevWiki = await readText(wikiPath)
-                .catch(err => err.code === 'ENOENT' ? '' : Promise.reject(err));
+                .catch(err => err.code === 'ENOENT' ? newPage : Promise.reject(err));
               if (!prevWiki) console.warn('Starting new wiki page for', folder.name);
 
               const newVersion = await readText(`outputs/${folder.name}/new-version.txt`);

--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -119,7 +119,7 @@ jobs:
             return numbers.join('.');
           result-encoding: string
 
-      - name: Store new version number
+      - name: Store version numbers
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -127,8 +127,36 @@ jobs:
           mkdir output
           echo '${{ steps.prev-version.outputs.result }}' > output/previous-version.txt
           echo '${{ steps.new-version.outputs.result }}' > output/new-version.txt
-          echo "* PR [#${{ github.event.pull_request.number }}]($PR_URL) - $(gh pr view $PR_URL --json title --jq .title )" > output/changelog.md
-          echo -e "\n\n\`\`\`\n$(gh pr view $PR_URL --json body --jq .body  )\n\`\`\`" >> output/changelog.md
+
+      - name: Extract changelog entry
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const { data: prInfo } = await github.rest.pulls.get({
+              owner, repo,
+              pull_number: context.issue.number,
+            });
+            console.log('Found PR body:|');
+            console.log(prInfo.body);
+
+            const changelogEntry = ((prInfo.body
+              .split(/^#+ ?/m)
+              .find(x => x.startsWith('Changelog'))
+              || '').split(/^```/m)[1] || '').trim();
+            if (!changelogEntry)
+              throw `'Changelog' section not found in PR body! Please add it back.`;
+            if (changelogEntry.match(/^TODO:/m))
+              throw `'Changelog' section needs proper text, instead of 'TODO'`;
+
+            const { writeFile } = require('fs').promises;
+            await writeFile('output/changelog.md', `
+            * PR [#${ prInfo.number }](${ prInfo.html_url }) - ${ prInfo.title }
+
+            \`\`\`
+            ${changelogEntry}
+            \`\`\`
+            `.trimLeft(), { encoding: 'utf-8' })
 
       - name: Document example 'source' line
         run: |


### PR DESCRIPTION
The CI will now pull the changelog text from the first codeblock found underneath a `/Changelog.+/` markdown heading.

## Changelog entry
```
TODO: Replace this inner text with a useful message
for users of the effected modules!
```